### PR TITLE
Add Prose support #38

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -1,6 +1,10 @@
 prose:
   rooturl: 'app/assets/content'
-  ignore: ['*/*.zip', '*/.gitkeep']
+  ignore: 
+    - '*/*.zip'
+    - '*/.gitkeep'
+    - '*/*.json'
+    - '*/*.jsonp'
   metadata:
     app/assets/content/projects:
       - name: 'title'
@@ -11,7 +15,7 @@ prose:
         field:
           element: 'text'
           label: 'Country code'
-          # options: 'https://rah.surge.sh/assets/content/countries.json'
+          options: 'https://rah.surge.sh/assets/content/countries.json?callback=countries_cb'
       - name: 'date'
         field:
           element: 'text'
@@ -20,13 +24,13 @@ prose:
         field:
           element: 'multiselect'
           label: 'Authors'
-          # options: 'https://rah.surge.sh/assets/content/authors.json'
+          options: 'https://rah.surge.sh/assets/content/authors.json?callback=authors_cb'
           alterable: true
       - name: 'topics'
         field:
           element: 'multiselect'
           label: 'Topics'
-          # options: 'https://rah.surge.sh/assets/content/topics.json'
+          options: 'https://rah.surge.sh/assets/content/topics.json?callback=topics_cb'
           alterable: true
       - name: 'contact_name'
         field:

--- a/_prose.yml
+++ b/_prose.yml
@@ -1,0 +1,38 @@
+prose:
+  rooturl: 'app/assets/content'
+  ignore: ['*/*.zip', '*/.gitkeep']
+  metadata:
+    app/assets/content/projects:
+      - name: 'title'
+        field:
+          element: 'text'
+          label: 'Title'
+      - name: 'country'
+        field:
+          element: 'text'
+          label: 'Country code'
+          # options: 'https://rah.surge.sh/assets/content/countries.json'
+      - name: 'date'
+        field:
+          element: 'text'
+          label: 'Date posted'
+      - name: 'authors'
+        field:
+          element: 'multiselect'
+          label: 'Authors'
+          # options: 'https://rah.surge.sh/assets/content/authors.json'
+          alterable: true
+      - name: 'topics'
+        field:
+          element: 'multiselect'
+          label: 'Topics'
+          # options: 'https://rah.surge.sh/assets/content/topics.json'
+          alterable: true
+      - name: 'contact_name'
+        field:
+          element: 'text'
+          label: 'Contact person'
+      - name: 'contact_email'
+        field:
+          element: 'text'
+          label: 'Contact email'

--- a/app/assets/content/projects/project-ram-demo-1/index.md
+++ b/app/assets/content/projects/project-ram-demo-1/index.md
@@ -10,6 +10,7 @@ contact:
   name: QL
   email: sample@sample.com
 published: true
+include_results: true
 contact_name: QL
 contact_email: sample@sample.com
 ---

--- a/app/assets/scripts/utils/countries.js
+++ b/app/assets/scripts/utils/countries.js
@@ -1,4 +1,4 @@
-export default [
+module.exports = [
   {
     'code': 'AF',
     'name': 'Afghanistan'


### PR DESCRIPTION
This PR adds Prose support to RAH. Currently done:

- [x] initial config for Prose
- [x] flatten contact object in RAM
- [x] add files for the Countries, Authors and Topics options
- [ ] change the documentation on content moderation

@danielfdsilva The `options` links are commented out. When enabled, Prose breaks, I suspect because it's not in the expected format.